### PR TITLE
Add reactive scrollable profile journal

### DIFF
--- a/client/src/Components/Profile/JournalModal.js
+++ b/client/src/Components/Profile/JournalModal.js
@@ -1,0 +1,108 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import * as React from 'react';
+import { useState } from 'react';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import CardMedia from '@mui/material/CardMedia';
+import CardContent from '@mui/material/CardContent';
+import Avatar from '@mui/material/Avatar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { red } from '@mui/material/colors';
+import StarIcon from '@mui/icons-material/Star';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import { makeStyles } from '@mui/styles';
+import Modal from '@mui/material/Modal';
+import Box from '@mui/material/Box';
+import CloseIcon from '@mui/icons-material/Close';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import TextField from '@mui/material/TextField';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  maxHeight: '98%',
+  background: '#000000e5',
+  border: '4px solid white',
+  boxShadow: 75,
+  borderRadius: '15px',
+};
+
+const useStyles = makeStyles(() => ({
+  root: {
+    flexGrow: 1,
+  },
+  bold: {
+    fontWeight: 600,
+  },
+  hover2: {
+    color: '#ffffff',
+    '&:hover': {
+      color: '#f0CC71',
+    },
+  },
+  hover3: {
+    color: '#A10000',
+    '&:hover': {
+      color: '#ffffff',
+    },
+  },
+  hover1: {
+    color: '#161513',
+    '&:hover': {
+      color: '#f0CC71',
+    },
+  },
+}));
+
+export default function JournalModal({ handleJournalClose, journalText }) {
+  const classes = useStyles();
+  const [newJournalText, setNewJournalText] = useState('');
+
+  const handleChange = (e) => {
+    setNewJournalText(e.target.value);
+    console.log('New journal text: ', newJournalText);
+  };
+
+  return (
+    <div className={classes.root}>
+      <Grid container style={{ justifyContent: 'flex-end' }}>
+        <IconButton onClick={handleJournalClose}>
+          <CloseIcon className={classes.hover3} style={{ fontSize: 45 }} />
+        </IconButton>
+      </Grid>
+      <TextField
+        name="itemDesc"
+        onChange={handleChange}
+        style={{
+          margin: '0 auto',
+          display: 'flex',
+          width: 400,
+          marginTop: 20,
+        }}
+        id="editItemDescription"
+        label="Journal entry for this item"
+        variant="filled"
+        multiline
+        rows={8}
+      />
+      <Button
+        style={{ margin: '0 auto', display: 'flex', marginTop: 20 }}
+        variant="contained"
+      >
+        Add Journal Entry
+      </Button>
+      <Button
+        onClick={handleJournalClose}
+        style={{ margin: '0 auto', display: 'flex', marginTop: 20 }}
+        variant="contained"
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/client/src/Components/Profile/Profile.js
+++ b/client/src/Components/Profile/Profile.js
@@ -14,7 +14,7 @@ import AddItem from './AddItem';
 const Profile = () => {
   const { currentUserState } = useContext(ItemsContext);
   const [currentUser] = currentUserState;
-  console.log('Current user: ', currentUser);
+  // console.log('Current user: ', currentUser);
 
   const testActiveItem = {
     itemName: 'Rustic Axe Set 1',
@@ -55,7 +55,7 @@ const Profile = () => {
                 height="200"
                 image={currentUser.userPFP}
                 style={{ objectFit: 'cover' }}
-                alt="Mr. Dahmer"
+                alt="Profile picture"
               />
             </Card>
             <EditProfileButton />

--- a/client/src/Components/Profile/ProfileJournal.js
+++ b/client/src/Components/Profile/ProfileJournal.js
@@ -1,0 +1,23 @@
+/* eslint-disable arrow-body-style */
+import React, { useState } from 'react';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import ProfileTabPanel from './ProfileTabPanel';
+import testJournal from './testJournal';
+import ProfileJournalEntry from './ProfileJournalEntry';
+
+// eslint-disable-next-line arrow-body-style
+const ProfileJournal = (props) => {
+  return (
+    <>
+      {testJournal.map((item, index) => {
+        return <ProfileJournalEntry activeItem={item} index={index} />;
+      })}
+    </>
+  );
+};
+
+export default ProfileJournal;

--- a/client/src/Components/Profile/ProfileJournalEntry.js
+++ b/client/src/Components/Profile/ProfileJournalEntry.js
@@ -1,0 +1,243 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import * as React from 'react';
+import { useState } from 'react';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import CardMedia from '@mui/material/CardMedia';
+import CardContent from '@mui/material/CardContent';
+import Avatar from '@mui/material/Avatar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { red } from '@mui/material/colors';
+import StarIcon from '@mui/icons-material/Star';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import { makeStyles } from '@mui/styles';
+import Modal from '@mui/material/Modal';
+import Box from '@mui/material/Box';
+import CloseIcon from '@mui/icons-material/Close';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import ItemModal from '../Feed/ItemModal';
+import JournalModal from './JournalModal';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  maxHeight: '98%',
+  background: '#000000e5',
+  border: '4px solid white',
+  boxShadow: 75,
+  borderRadius: '15px',
+};
+
+const useStyles = makeStyles(() => ({
+  root: {
+    flexGrow: 1,
+  },
+  bold: {
+    fontWeight: 600,
+  },
+  hover2: {
+    color: '#ffffff',
+    '&:hover': {
+      color: '#f0CC71',
+    },
+  },
+  hover3: {
+    color: '#A10000',
+    '&:hover': {
+      color: '#ffffff',
+    },
+  },
+  hover1: {
+    color: '#161513',
+    '&:hover': {
+      color: '#f0CC71',
+    },
+  },
+}));
+
+export default function ProfileJournalEntry(props) {
+  const classes = useStyles();
+  // mouse over image
+
+  // star fill
+  const [starFill, setStarFill] = React.useState(false);
+  const handleWatch = () => {
+    setStarFill(true);
+  };
+  const handleUnwatch = () => {
+    setStarFill(false);
+  };
+  // item modal
+  const [openCard, setCardOpen] = useState(false);
+  const [openJournal, setJournalOpen] = useState(false);
+
+  const handleCardOpen = () => setCardOpen(true);
+  const handleCardClose = () => setCardOpen(false);
+
+  const handleJournalOpen = () => setJournalOpen(true);
+  const handleJournalClose = () => setJournalOpen(false);
+  const handleRelistOpen = () => alert("Don't touch that.");
+
+  const { itemName, itemDesc, itemOwner, itemPicture } =
+    props.activeItem.journalItem;
+
+  return (
+    <div className={classes.root} key={props.index}>
+      <Modal open={openCard} onClose={handleCardClose}>
+        <Box style={{ overflow: 'auto' }} sx={style}>
+          <ItemModal
+            handleCardClose={handleCardClose}
+            starFill={starFill}
+            handleWatch={handleWatch}
+            handleUnwatch={handleUnwatch}
+          />
+        </Box>
+      </Modal>
+
+      <Modal open={openJournal} onClose={handleJournalClose}>
+        <Box sx={style} style={{ backgroundColor: '#494D53', maxWidth: '25%' }}>
+          <JournalModal
+            handleJournalClose={handleJournalClose}
+            journalText={props.activeItem.journalText}
+          />
+        </Box>
+      </Modal>
+
+      <Grid container>
+        <Card
+          style={{
+            backgroundColor: '#494D53',
+            border: '1px solid',
+            borderColor: '#FFF',
+            borderRadius: '15px',
+            paddingBottom: -50,
+          }}
+        >
+          <CardMedia
+            component="img"
+            height={props.height}
+            image="https://images.squarespace-cdn.com/content/v1/5acd0a3c8ab722892928be5a/1565878992439-2ER3KM60OHYNPNF2LPP3/8B059829-6D7F-424F-B9A7-4C44C112CFF9.jpg?format=2500w"
+            style={{ objectFit: 'cover' }}
+            alt="Axe Set"
+            onClick={handleCardOpen}
+          />
+          <Grid container style={{ marginTop: '6px' }}>
+            <Grid
+              container
+              item
+              xs={10}
+              justifyContent="flex-start"
+              alignItems="baseline"
+            >
+              <Typography
+                variant="h5"
+                style={{ marginLeft: '22px', color: '#F0CC71' }}
+              >
+                {itemName}
+              </Typography>
+            </Grid>
+            <Grid container item xs={2} justifyContent="center">
+              {!starFill && (
+                <IconButton onClick={handleWatch}>
+                  <StarIcon className={classes.hover1} />
+                </IconButton>
+              )}
+              {starFill && (
+                <IconButton onClick={handleUnwatch}>
+                  <StarIcon
+                    className={classes.hover1}
+                    style={{ color: '#F0CC71' }}
+                  />
+                </IconButton>
+              )}
+            </Grid>
+          </Grid>
+          <CardHeader
+            avatar={
+              <Avatar
+                sx={{ bgcolor: red[500], marginLeft: '8px' }}
+                aria-label="user_name"
+              />
+            }
+            title="Jeffrey Dahmer"
+            subheader="6 hours ago"
+            style={{
+              marginBottom: '-20px',
+              marginTop: '-12px',
+              color: '#FFFFFF',
+            }}
+          />
+          <CardContent>
+            <Grid
+              container
+              item
+              xs={12}
+              justifyContent="center"
+              style={{ marginBottom: '20px' }}
+            >
+              <Typography
+                variant="body2"
+                color="white"
+                style={{ marginLeft: '10px' }}
+                display="inline"
+              >
+                {'These beautiful axes were custom made in the heart of Minnesota' +
+                  '... '}
+                <Link
+                  className={classes.hover1}
+                  component="button"
+                  underline="none"
+                  display="inline"
+                  color="cardButton"
+                  onClick={handleCardOpen}
+                >
+                  Read more
+                </Link>
+              </Typography>
+            </Grid>
+            <Grid container item xs={12} justifyContent="center">
+              {props.activeItem.journalText.length <= 0 && (
+                <Grid container item xs={6} justifyContent="center">
+                  <Button
+                    color="inherit"
+                    variant="outlined"
+                    className={classes.hover2}
+                    onClick={handleJournalOpen}
+                  >
+                    Add Journal Entry For Item
+                  </Button>
+                </Grid>
+              )}
+              {props.activeItem.journalText.length > 0 && (
+                <Typography
+                  variant="body2"
+                  color="white"
+                  style={{ marginLeft: '10px', marginBottom: '10px' }}
+                  display="inline"
+                >
+                  Journal Entry: {props.activeItem.journalText}
+                </Typography>
+              )}
+              <Grid container item xs={6} justifyContent="space-evenly">
+                <Button
+                  color="inherit"
+                  variant="outlined"
+                  className={classes.hover2}
+                  onClick={handleRelistOpen}
+                >
+                  Re-List Item
+                </Button>
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      </Grid>
+    </div>
+  );
+}

--- a/client/src/Components/Profile/ProfileTabs.js
+++ b/client/src/Components/Profile/ProfileTabs.js
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import ProfileTabPanel from './ProfileTabPanel';
 import WatchedItems from './WatchedItems';
+import ProfileJournal from './ProfileJournal';
 
 const ProfileTabs = () => {
   const [value, setValue] = useState(0);
@@ -37,9 +38,10 @@ const ProfileTabs = () => {
             backgroundColor: '#494D53',
             marginLeft: -3,
             marginTop: -2,
+            overflow: 'auto',
           }}
         >
-          Trade Journey Journal
+          <ProfileJournal />
         </Card>
       </ProfileTabPanel>
       <ProfileTabPanel value={value} index={1}>

--- a/client/src/Components/Profile/testJournal.js
+++ b/client/src/Components/Profile/testJournal.js
@@ -1,0 +1,44 @@
+const testJournal = [
+  {
+    journalItem: {
+      itemName: 'Rustic Axe Set 1',
+      itemDesc:
+        'These beautiful axes were custom made in the heart of Minnesota. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing.',
+      itemOwner: 'Jeffrey Dahmer',
+      itemPicture:
+        'https://images.squarespace-cdn.com/content/v1/5acd0a3c8ab722892928be5a/1565878992439-2ER3KM60OHYNPNF2LPP3/8B059829-6D7F-424F-B9A7-4C44C112CFF9.jpg?format=2500w',
+    },
+    journalDate: new Date(),
+    journalLoc: 'here and now',
+    journalText: '',
+  },
+  {
+    journalItem: {
+      itemName: 'Rustic Axe Set 2',
+      itemDesc:
+        'These beautiful axes were custom made in the heart of Minnesota. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing.',
+      itemOwner: 'Jeffrey Dahmer',
+      itemPicture:
+        'https://images.squarespace-cdn.com/content/v1/5acd0a3c8ab722892928be5a/1565878992439-2ER3KM60OHYNPNF2LPP3/8B059829-6D7F-424F-B9A7-4C44C112CFF9.jpg?format=2500w',
+    },
+    journalDate: new Date(),
+    journalLoc: 'here and now',
+    journalText:
+      'Traded this set for some lovely knives. Lovely, lovely knives...',
+  },
+  {
+    journalItem: {
+      itemName: 'Rustic Axe Set 3',
+      itemDesc:
+        'These beautiful axes were custom made in the heart of Minnesota. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing. I need to have more characters so I am typing.',
+      itemOwner: 'Jeffrey Dahmer',
+      itemPicture:
+        'https://images.squarespace-cdn.com/content/v1/5acd0a3c8ab722892928be5a/1565878992439-2ER3KM60OHYNPNF2LPP3/8B059829-6D7F-424F-B9A7-4C44C112CFF9.jpg?format=2500w',
+    },
+    journalDate: new Date(),
+    journalLoc: 'here and now',
+    journalText: 'Oh shoot, did I remember to clean this?',
+  },
+];
+
+export default testJournal;


### PR DESCRIPTION
Added formatting for the user journal. I still need to hook it up to the API, but the formatting is there with dummy data. The "add journal entry" button renders conditionally; if there's journal text, it just shows it in a typography element instead of the button. I should also make another pass over it later to tidy up the code and styling; I appropriated more of Blake's code and hacked it up to keep the styling intact.

Also, there's an alert on the "Re-list Item" button; I think we mentioned that we're going to cut that functionality, so I can pull out the button entirely if needed. There's also a React warning in the console that I couldn't get rid of; I'll ask about it in the morning and push as soon as I have a fix.